### PR TITLE
Fix typo

### DIFF
--- a/auth/app/controllers/accounts_controller.rb
+++ b/auth/app/controllers/accounts_controller.rb
@@ -45,7 +45,7 @@ class AccountsController < ApplicationController
         if new_role
           event = {
             event_name: 'AccountRoleChanged',
-            data: { public_id: public_id, role: role }
+            data: { public_id: @account.public_id, role: role }
           }
           WaterDrop::SyncProducer.call(event.to_json, topic: 'accounts')
         end


### PR DESCRIPTION
`public_id` variable on line 48 probably belongs to `@account`
```
48:    data: { public_id: @account.public_id, role: role }
```